### PR TITLE
Init single client

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,10 +11,10 @@ import (
 )
 
 type Proxy struct {
+	client    *http.Client
 	proxyIp   string
 	proxyPort string
 	proxyPath string
-	client    *http.Client
 }
 
 func (p *Proxy) ServeHTTP(wr http.ResponseWriter, r *http.Request) {
@@ -85,10 +85,10 @@ func main() {
 	client := &http.Client{Transport: transport}
 
 	proxy := &Proxy{
+		client: client,
 		proxyIp: *proxyIp,
 		proxyPort: *proxyPort,
 		proxyPath: *proxyPath,
-		client: client,
 	}
 
 	err = http.ListenAndServe(*bindIp + ":" + *bindPort, proxy)

--- a/main.go
+++ b/main.go
@@ -14,17 +14,14 @@ type Proxy struct {
 	proxyIp   string
 	proxyPort string
 	proxyPath string
-	tlsConfig *tls.Config
+	client    *http.Client
 }
 
 func (p *Proxy) ServeHTTP(wr http.ResponseWriter, r *http.Request) {
 	var resp *http.Response
 	var err error
 
-	transport := &http.Transport{TLSClientConfig: p.tlsConfig}
-	client := &http.Client{Transport: transport}
-
-	resp, err = client.Get("https://" + p.proxyIp + ":" + p.proxyPort + p.proxyPath)
+	resp, err = p.client.Get("https://" + p.proxyIp + ":" + p.proxyPort + p.proxyPath)
 
 	if err != nil {
 		http.Error(wr, err.Error(), http.StatusInternalServerError)
@@ -84,11 +81,14 @@ func main() {
 		return
 	}
 
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	client := &http.Client{Transport: transport}
+
 	proxy := &Proxy{
 		proxyIp: *proxyIp,
 		proxyPort: *proxyPort,
 		proxyPath: *proxyPath,
-		tlsConfig: tlsConfig,
+		client: client,
 	}
 
 	err = http.ListenAndServe(*bindIp + ":" + *bindPort, proxy)


### PR DESCRIPTION
As of now we are opening a new http client for each connection. This results in a new connection on each request. Regarding to the docs[1] Transport and Client are safe for concurrent use. Thus initialize the client only once on init.

[1] https://golang.org/pkg/net/http